### PR TITLE
Improve ARM platform matching

### DIFF
--- a/platforms/compare.go
+++ b/platforms/compare.go
@@ -29,11 +29,48 @@ type MatchComparer interface {
 // Only returns a match comparer for a single platform
 // using default resolution logic for the platform.
 //
+// For ARMv8, will also match ARMv7, ARMv6 and ARMv5 (for 32bit runtimes)
 // For ARMv7, will also match ARMv6 and ARMv5
 // For ARMv6, will also match ARMv5
 func Only(platform specs.Platform) MatchComparer {
 	platform = Normalize(platform)
 	if platform.Architecture == "arm" {
+		if platform.Variant == "v8" {
+			return orderedPlatformComparer{
+				matchers: []Matcher{
+					&matcher{
+						Platform: platform,
+					},
+					&matcher{
+						Platform: specs.Platform{
+							Architecture: platform.Architecture,
+							OS:           platform.OS,
+							OSVersion:    platform.OSVersion,
+							OSFeatures:   platform.OSFeatures,
+							Variant:      "v7",
+						},
+					},
+					&matcher{
+						Platform: specs.Platform{
+							Architecture: platform.Architecture,
+							OS:           platform.OS,
+							OSVersion:    platform.OSVersion,
+							OSFeatures:   platform.OSFeatures,
+							Variant:      "v6",
+						},
+					},
+					&matcher{
+						Platform: specs.Platform{
+							Architecture: platform.Architecture,
+							OS:           platform.OS,
+							OSVersion:    platform.OSVersion,
+							OSFeatures:   platform.OSFeatures,
+							Variant:      "v5",
+						},
+					},
+				},
+			}
+		}
 		if platform.Variant == "v7" {
 			return orderedPlatformComparer{
 				matchers: []Matcher{

--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -97,7 +97,7 @@ func getCPUVariant() string {
 	}
 
 	switch variant {
-	case "8":
+	case "8", "AArch64":
 		variant = "v8"
 	case "7", "7M", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
 		variant = "v7"


### PR DESCRIPTION
This commit improves ARM platform matching in two instances:

* Some old kernels reported the CPU architecture of arm64 cpus as
  Aarch64 [1].
* In cases where the user is running with armv8 cpu and kernel but amrhf
  user land (so armhf containerd), a possibility given the compatibility
  of armv8 with armv7.

[1] https://elixir.bootlin.com/linux/v3.14.29/source/arch/arm64/kernel/setup.c#L420

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@suse.com>